### PR TITLE
Add AMD (asynchronous module definition) support

### DIFF
--- a/jquery.easing.1.3.js
+++ b/jquery.easing.1.3.js
@@ -35,6 +35,16 @@
  *
 */
 
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(function (jQuery) {
+
 // t: current time, b: begInnIng value, c: change In value, d: duration
 jQuery.easing['jswing'] = jQuery.easing['swing'];
 
@@ -170,6 +180,8 @@ jQuery.extend( jQuery.easing,
 		return jQuery.easing.easeOutBounce (x, t*2-d, 0, c, d) * .5 + c*.5 + b;
 	}
 });
+
+}));
 
 /*
  *


### PR DESCRIPTION
This pull request adds support for [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD), as used by module loaders such as require.js (with fallback if a module loader is not present).

I see you have multiple files for multiple versions, which is a bit unorthodox as one usually keep one file and manage different releases via git tags.

Because of this, I'm not sure how or in which file I should make a pull request.

This pull request's change is in the 1.3 file.

