### PR TITLE
Move uglify params to script definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ define(['jquery', 'jquery.easing'], function (jQuery, easing) {
 * `npm install`
 * Make changes
 * Test against files in `/examples`
-* Build minified version with `npm run uglify -- --compress --mangle`
+* Build minified version with `npm run build`

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "test": "echo \"Use tests in the examples directory\" && exit 1",
-    "uglify": "uglifyjs jquery.easing.js -o jquery.easing.min.js"
+    "build": "uglifyjs jquery.easing.js --compress --mangle -o jquery.easing.min.js"
   },
   "devDependencies": {
     "jquery": ">=1.3.0",


### PR DESCRIPTION
Follows-up 46ba111.

Instead of passing these as custom parameters to npm run,
it probably makes more sense to have them there by default
so that the command is always correct in the long term
even when the params or file names change again - without having
to check the readme each time.